### PR TITLE
Extra arguments are allowed by default

### DIFF
--- a/test/gfx/001_basic.rb
+++ b/test/gfx/001_basic.rb
@@ -22,8 +22,5 @@ class Test001Basic < Test::Unit::TestCase
 
     assert_raise_message(/foo/) { v.validate() }
     assert_raise_message(/foo/) { v.validate({'foo' => 'bar'}) }
-    assert_raise_message(/baz|qux/) {
-      v.validate({'foo' => 0, 'baz' => 42, qux => 100 })
-    }
   end
 end

--- a/test/gfx/104_extra_args.rb
+++ b/test/gfx/104_extra_args.rb
@@ -6,7 +6,7 @@ class Test104ExtraArgs < Test::Unit::TestCase
   def test_test
     v = Data::Validator.new(
       'foo' => { },
-    ).with('AllowExtra')
+    )
 
     args = v.validate('foo' => 42, 'bar' => 15)
     assert { args == {'foo' => 42, 'bar' => 15} }


### PR DESCRIPTION
Hi,

As far as I see, extra arguments are allowed by default.
Current test cases confused me.
So I send this request.
Though I don't understand `#with('AllowExtra')` feature yet.
(Maybe is this unexpected that extra args allowed by default?)

This is a trivial request.

I ran `rake test` with ruby 2.2.0 and 2.3.0 on my machine Mac OSX.