### PR TITLE
add lib/data.rb for future deletion of ::Data

### DIFF
--- a/lib/data.rb
+++ b/lib/data.rb
@@ -1,0 +1,38 @@
+#! /your/favourite/path/to/ruby
+# -*- mode: ruby; coding: utf-8; indent-tabs-mode: nil; ruby-indent-level 2 -*-
+
+# Copyright (c) 2018 Urabe, Shyouhei
+#
+# Permission is hereby granted, free of  charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction,  including without limitation the rights
+# to use,  copy, modify,  merge, publish,  distribute, sublicense,  and/or sell
+# copies  of the  Software,  and to  permit  persons to  whom  the Software  is
+# furnished to do so, subject to the following conditions:
+#
+#         The above copyright notice and this permission notice shall be
+#         included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE  IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY  KIND, EXPRESS OR
+# IMPLIED,  INCLUDING BUT  NOT LIMITED  TO THE  WARRANTIES OF  MERCHANTABILITY,
+# FITNESS FOR A  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO  EVENT SHALL THE
+# AUTHORS  OR COPYRIGHT  HOLDERS  BE LIABLE  FOR ANY  CLAIM,  DAMAGES OR  OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Toplevel namespace `::Data` got deprecated, and will eventually be disappear.
+# However we are using it because p5-Data-Validator is in this namespace.  This
+# has nothing to do with the deprecation of Ruby's `::Data`.
+if defined? ::Data
+  # We have to shut up the deprecation warning.
+  class << Warning
+    prepend Module.new {
+      def warn str
+        super unless /::Data is deprecated/ =~ str
+      end
+    }
+  end
+else
+  Data = Class.new # create one here
+end

--- a/lib/data/validator.rb
+++ b/lib/data/validator.rb
@@ -20,6 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+require_relative '../data'
 Data::Validator = Class.new  # @!parse class Data::Validator; end
 require_relative "validator/version"
 


### PR DESCRIPTION
@hirose31

It seems there is no way to "cancel" the deprecation.  I can think of several ways to workaround, but simply:  why not just suppress the warning?  Here's the patch.