### PR TITLE
Check missing even if with AllowExtra

### DIFF
--- a/lib/data/validator.rb
+++ b/lib/data/validator.rb
@@ -177,6 +177,8 @@ class Data::Validator
         fillin << key
       elsif rule[:optional] then
         # ok
+      elsif @isa then
+        missing << key
       elsif @rule[:allow_extra] then
         # ok
       else

--- a/test/02_validate_requires_allowextra.rb
+++ b/test/02_validate_requires_allowextra.rb
@@ -1,0 +1,30 @@
+require 'test-unit'
+require 'data/validator'
+
+class Test02Validate < Test::Unit::TestCase
+  test 'requires with AllowExtra' do
+    rule = Data::Validator::Recursive.new(
+      'foo' => String,
+      'bar' => { isa: Integer, default: 1 },
+      'baz' => {
+        isa: Hash,
+        with: 'AllowExtra',
+        rule: {
+          'hoge' => { isa: String }, # requires
+          'fuga' => Integer,
+        },
+      },
+    ).with('AllowExtra')
+
+    input = {
+      'foo' => 'xxx',
+      'baz' => {
+        'fuga' => 123,
+        'extra_param_in_baz' => 1,
+      },
+      'extra_param' => 1,
+    }
+
+    assert_raise_message(/missing/) { rule.validate(input) }
+  end
+end


### PR DESCRIPTION
This PR makes to check required parameters even if with `AllowExtra` option.

```rb
require 'data/validator'

rule = Data::Validator::Recursive.new(
  'foo' => String,
  'bar' => String, # required!
).with('AllowExtra')

input = {
  'foo' => 'FOO',
  # 'bar' => 'BAR',
  'extra_param' => 1,
}

p rule.validate(input)

# data-validator 1.1.2
# => {"foo"=>"FOO", "extra_param"=>1}

# this PR
# ... `validate_hash': ["bar"] missing (Data::Validator::Error)

```